### PR TITLE
fix(workflow): exclude spectra from legacy publish

### DIFF
--- a/.github/workflows/sdtokens-merkle.yaml
+++ b/.github/workflows/sdtokens-merkle.yaml
@@ -126,6 +126,11 @@ jobs:
             for file in bounties-reports/${PERIOD}/sdTkns/sdtkns_merkle_*.json; do
               if [ -f "$file" ]; then
                 filename=$(basename "$file")
+                # Skip spectra (8453) - handled separately via orchestrator
+                if [[ "$filename" == "sdtkns_merkle_8453.json" ]]; then
+                  echo "Skipping $filename (spectra - handled by orchestrator)"
+                  continue
+                fi
                 cp "$file" "bounties-reports/latest/sdTkns/${filename}"
               fi
             done


### PR DESCRIPTION
## Summary
- Skip `sdtkns_merkle_8453.json` (spectra) in the legacy publish step

## Problem
The legacy publish step copies ALL `sdtkns_merkle_*.json` files to `latest/`, including spectra (8453). But spectra is now handled separately via orchestrator's periodic acceptRoot flow, so it shouldn't be published by the legacy workflow.

## Test plan
- [ ] Run `sdtokens-merkle` with `token=legacy`, `step=publish`
- [ ] Verify `sdtkns_merkle_8453.json` is NOT copied to `latest/sdTkns/`
- [ ] Verify other sdtkns merkle files ARE copied