### PR TITLE
Re-land #120: use envio instead of github

### DIFF
--- a/script/helpers/computeSpectraDelegatorsAPR.ts
+++ b/script/helpers/computeSpectraDelegatorsAPR.ts
@@ -24,7 +24,7 @@ import { createBlockchainExplorerUtils } from "../utils/explorerUtils";
 import { BOTMARKET } from "../utils/reportUtils";
 import { getSpectraRewards, getsdSpectraDistributed } from "./utils";
 import { SPECTRA_ADDRESS } from "../spectra/utils";
-import axios from "axios";
+import { fetchGlobalTotalVp } from "../utils/envioClient";
 
 interface APRResult {
   totalVotingPower: number;
@@ -225,13 +225,11 @@ async function computeAPR(): Promise<APRResult> {
 
   // Calculate annualized APRs
   // Because we do a weekly distribution, multiply by 52
-  const { data: sdSpectraWorking } = await axios.get(
-    "https://raw.githubusercontent.com/stake-dao/api/refs/heads/main/api/lockers/sdspectra-working-supply.json"
-  )
+  const spectraTotalVp = await fetchGlobalTotalVp("sdspectra");
 
-  const annualizedAPR = ((totalSdSpectraDistributed * 52) / (sdSpectraWorking.total_vp)) * 100;
-  const wethAPR = ((wethRewardValueUSD * 52) / (sdSpectraWorking.total_vp)) * 100;
-  const otherAPR = ((otherRewardValueUSD * 52) / (sdSpectraWorking.total_vp)) * 100;
+  const annualizedAPR = ((totalSdSpectraDistributed * 52) / spectraTotalVp) * 100;
+  const wethAPR = ((wethRewardValueUSD * 52) / spectraTotalVp) * 100;
+  const otherAPR = ((otherRewardValueUSD * 52) / spectraTotalVp) * 100;
 
   console.log("\n=== APR Calculations ===");
   console.log("Weekly Reward:", totalRewardUSD);

--- a/script/sdTkns/generateMerkle.ts
+++ b/script/sdTkns/generateMerkle.ts
@@ -4,6 +4,7 @@ import {
   fetchLastProposalsIds,
   fetchProposalsIdsBasedOnExactPeriods,
 } from "../utils/snapshot";
+import { fetchGlobalTotalVp } from "../utils/envioClient";
 import {
   abi,
   NETWORK_TO_MERKLE,
@@ -222,7 +223,7 @@ const main = async () => {
     { data: lastMerkles },
     proposalIdPerSpace,
     { data: delegationAPRsFromGithub },
-    { data: sdFXSWorkingData },
+    sdFXSTotalVp,
     { data: sdCakeWorkingData },
   ] = await Promise.all([
     axios.get(
@@ -232,13 +233,13 @@ const main = async () => {
     axios.get(
       "https://raw.githubusercontent.com/stake-dao/bounties-report/main/bounties-reports/latest/delegationsAPRs.json"
     ),
-    axios.get(
-      "https://raw.githubusercontent.com/stake-dao/api/refs/heads/main/api/lockers/sdfxs-working-supply.json"
-    ),
+    fetchGlobalTotalVp("sdfxs"),
     axios.get(
       "https://raw.githubusercontent.com/stake-dao/api/refs/heads/main/api/lockers/sdcake-working-supply.json"
     ),
   ]);
+
+  const sdFXSWorkingData = { total_vp: sdFXSTotalVp };
 
   // Check if local delegationsAPRs.json exists for current period (e.g., written by Spectra)
   // If so, use it to preserve APRs from other scripts that ran before

--- a/script/spectra/utils.ts
+++ b/script/spectra/utils.ts
@@ -14,7 +14,7 @@ import {
 } from "../utils/utils";
 import * as dotenv from "dotenv";
 import { getClient } from "../utils/constants";
-import axios from "axios";
+import { fetchSpectraUsersWorkingBalance } from "../utils/envioClient";
 
 dotenv.config();
 
@@ -223,30 +223,20 @@ export const getSpectraDelegationAPR = async (
   },
   stakeDaoDelegators: string[]
 ): Promise<number> => {
-  const sumRewards = parseFloat(formatUnits(Object.values(tokens)[0], 18))
-  const {data: sdSpectraWorking} = await axios.get(
-    "https://raw.githubusercontent.com/stake-dao/api/refs/heads/main/api/lockers/sdspectra-working-supply.json"
-  )
+  const sumRewards = parseFloat(formatUnits(Object.values(tokens)[0], 18));
+  const usersWorkingBalance = await fetchSpectraUsersWorkingBalance(stakeDaoDelegators);
 
   let totalVpDelegators = 0;
-  const users = Object.keys(sdSpectraWorking.users_working_balance)
-
-  for(const delegator of stakeDaoDelegators) {
-    let found = false
-    for(const user of users) {
-      if(delegator.toLowerCase() === user.toLowerCase()) {
-        totalVpDelegators += sdSpectraWorking.users_working_balance[user];
-        found = true
-        break;
-      }
-    }
-
-    if(!found) {
-      console.log("Delegator not found" + delegator);
+  for (const delegator of stakeDaoDelegators) {
+    const wb = usersWorkingBalance[delegator.toLowerCase()];
+    if (wb) {
+      totalVpDelegators += wb;
+    } else {
+      console.log("Delegator not found " + delegator);
     }
   }
-  
+
   // Because we do a weekly distribution
-  return sumRewards / totalVpDelegators * 52 * 100;
+  return (sumRewards / totalVpDelegators) * 52 * 100;
 };
 

--- a/script/utils/envioClient.ts
+++ b/script/utils/envioClient.ts
@@ -1,0 +1,61 @@
+import { formatUnits } from "viem";
+import * as dotenv from "dotenv";
+
+dotenv.config();
+
+const fetchGraphQL = async (query: string, variables?: Record<string, any>) => {
+  const res = await fetch(process.env.BOTS_ENVIO_GRAPHQL_URL_WORKER || "", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query, variables }),
+  });
+  const json = await res.json();
+  if (json.errors) {
+    throw new Error(`GraphQL error: ${JSON.stringify(json.errors)}`);
+  }
+  return json.data;
+};
+
+const toFloat = (raw: string) => Number(formatUnits(BigInt(raw), 18));
+
+/**
+ * Fetch global totalVotingPower for a protocol.
+ * Equivalent to `total_vp` from the old GitHub JSON files.
+ */
+export async function fetchGlobalTotalVp(
+  protocol: "sdfxs" | "sdspectra"
+): Promise<number> {
+  if (protocol === "sdfxs") {
+    const data = await fetchGraphQL(
+      `{ SdFxsGlobalState_by_pk(id: "global") { totalVotingPower } }`
+    );
+    return toFloat(data.SdFxsGlobalState_by_pk?.totalVotingPower ?? "0");
+  }
+
+  const data = await fetchGraphQL(
+    `{ SdSpectraGlobalState_by_pk(id: "global") { totalVotingPower } }`
+  );
+  return toFloat(data.SdSpectraGlobalState_by_pk?.totalVotingPower ?? "0");
+}
+
+/**
+ * Fetch working balances for a list of user addresses (sdSpectra).
+ * Returns a Record<lowercaseAddress, workingBalance>.
+ */
+export async function fetchSpectraUsersWorkingBalance(
+  userAddresses: string[]
+): Promise<Record<string, number>> {
+  const lowered = userAddresses.map((a) => a.toLowerCase());
+  const data = await fetchGraphQL(
+    `query($ids: [String!]!) {
+      SdSpectraUser(where: { id: { _in: $ids } }) { id workingBalance }
+    }`,
+    { ids: lowered }
+  );
+
+  const result: Record<string, number> = {};
+  for (const u of data.SdSpectraUser ?? []) {
+    result[u.id] = toFloat(u.workingBalance);
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
Re-lands PR #120 (reverted in #124) by reverting the revert commit `c78617c5`. No code changes vs the original — diff is byte-identical to the reverted merge.
