### PR TITLE
fix(workflows): verify on-chain root before publishing merkle to latest/

### DIFF
--- a/.github/workflows/vlaura-distribution.yaml
+++ b/.github/workflows/vlaura-distribution.yaml
@@ -149,6 +149,13 @@ jobs:
 
           echo "skip=false" >> $GITHUB_OUTPUT
 
+      # ── Safeguard: verify on-chain root matches source before publishing ──
+      - name: Verify on-chain root matches source
+        if: inputs.step == 'publish' && steps.check_published.outputs.skip != 'true'
+        run: pnpm tsx script/helpers/verifyOnchainRoot.ts --target vlaura --period ${{ steps.period.outputs.current }}
+        env:
+          WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
+
       # ── Compute APR ──
       - name: Compute APR
         if: inputs.step == 'publish' && steps.check_published.outputs.skip != 'true'

--- a/.github/workflows/vlcvx-distribution.yaml
+++ b/.github/workflows/vlcvx-distribution.yaml
@@ -181,6 +181,13 @@ jobs:
 
           echo "skip=false" >> $GITHUB_OUTPUT
 
+      # ── Safeguard: verify on-chain root matches source before publishing ──
+      - name: Verify on-chain root matches source
+        if: inputs.step == 'publish' && steps.check_published.outputs.skip != 'true'
+        run: pnpm tsx script/helpers/verifyOnchainRoot.ts --target ${{ inputs.type }} --period ${{ steps.period.outputs.current }}
+        env:
+          WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
+
       # ── Compute APR (delegators only — needs sCRVUSD transfers from Tuesday distribution) ──
       - name: Compute APR
         if: inputs.type == 'delegators' && inputs.step == 'publish' && steps.check_published.outputs.skip != 'true'

--- a/script/helpers/verifyOnchainRoot.ts
+++ b/script/helpers/verifyOnchainRoot.ts
@@ -1,0 +1,165 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { getClient } from "../utils/getClients";
+
+const URD_ABI = [
+  {
+    name: "root",
+    type: "function",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "bytes32" }],
+  },
+] as const;
+
+type Target = "delegators" | "voters" | "vlaura";
+
+interface FileSpec {
+  path: string;
+  chainId: number;
+  distributor: `0x${string}`;
+}
+
+const VLCVX_DELEGATORS: Record<number, `0x${string}`> = {
+  1: "0x17F513CDE031C8B1E878Bde1Cb020cE29f77f380",
+};
+
+const VLCVX_VOTERS: Record<number, `0x${string}`> = {
+  1: "0x000000006feeE0b7a0564Cd5CeB283e10347C4Db",
+  10: "0x000000006feeE0b7a0564Cd5CeB283e10347C4Db",
+  42161: "0x000000006feeE0b7a0564Cd5CeB283e10347C4Db",
+  8453: "0x000000006feeE0b7a0564Cd5CeB283e10347C4Db",
+};
+
+const VLAURA: Record<number, `0x${string}`> = {
+  1: "0x59ADeBc5cBdB18aE344a506976fE3bbBB3D89199",
+  42161: "0x59ADeBc5cBdB18aE344a506976fE3bbBB3D89199",
+  8453: "0x59ADeBc5cBdB18aE344a506976fE3bbBB3D89199",
+};
+
+function collectFiles(target: Target, period: number): FileSpec[] {
+  const vlcvxDir = path.join("bounties-reports", String(period), "vlCVX");
+  const vlauraDir = path.join("bounties-reports", String(period), "vlAURA");
+  const files: FileSpec[] = [];
+
+  if (target === "delegators") {
+    files.push({
+      path: path.join(vlcvxDir, "merkle_data_delegators.json"),
+      chainId: 1,
+      distributor: VLCVX_DELEGATORS[1],
+    });
+    return files;
+  }
+
+  if (target === "voters") {
+    files.push({
+      path: path.join(vlcvxDir, "vlcvx_merkle.json"),
+      chainId: 1,
+      distributor: VLCVX_VOTERS[1],
+    });
+    for (const chainId of [10, 42161, 8453]) {
+      const p = path.join(vlcvxDir, `vlcvx_merkle_${chainId}.json`);
+      if (existsSync(p)) {
+        files.push({ path: p, chainId, distributor: VLCVX_VOTERS[chainId] });
+      }
+    }
+    return files;
+  }
+
+  // vlaura
+  files.push({
+    path: path.join(vlauraDir, "vlaura_merkle.json"),
+    chainId: 1,
+    distributor: VLAURA[1],
+  });
+  for (const chainId of [42161, 8453]) {
+    const p = path.join(vlauraDir, `vlaura_merkle_${chainId}.json`);
+    if (existsSync(p)) {
+      files.push({ path: p, chainId, distributor: VLAURA[chainId] });
+    }
+  }
+  return files;
+}
+
+async function verifyFile(spec: FileSpec): Promise<{ ok: boolean; source: string; onchain: string }> {
+  const raw = readFileSync(spec.path, "utf8");
+  const data = JSON.parse(raw) as { merkleRoot?: string };
+  if (!data.merkleRoot) {
+    throw new Error(`merkleRoot field missing in ${spec.path}`);
+  }
+  const source = data.merkleRoot.toLowerCase();
+  const client = await getClient(spec.chainId);
+  const onchain = (await client.readContract({
+    address: spec.distributor,
+    abi: URD_ABI,
+    functionName: "root",
+  })) as `0x${string}`;
+  const onchainLower = onchain.toLowerCase();
+  return { ok: source === onchainLower, source, onchain: onchainLower };
+}
+
+function parseArg(name: string): string | undefined {
+  const args = process.argv.slice(2);
+  const i = args.findIndex((a) => a === `--${name}`);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+async function main() {
+  const target = parseArg("target") as Target | undefined;
+  const periodStr = parseArg("period");
+
+  if (!target || !periodStr) {
+    console.error(
+      "Usage: verifyOnchainRoot --target <delegators|voters|vlaura> --period <timestamp>",
+    );
+    process.exit(2);
+  }
+  if (!["delegators", "voters", "vlaura"].includes(target)) {
+    console.error(`Unknown target: ${target}`);
+    process.exit(2);
+  }
+
+  const period = Number(periodStr);
+  if (!Number.isFinite(period) || period <= 0) {
+    console.error(`Invalid period: ${periodStr}`);
+    process.exit(2);
+  }
+
+  const files = collectFiles(target, period);
+  const missingMain = !existsSync(files[0].path);
+  if (missingMain) {
+    console.error(`Source file not found: ${files[0].path}`);
+    process.exit(3);
+  }
+
+  console.log(`Verifying on-chain roots for target=${target} period=${period}`);
+  let allOk = true;
+
+  for (const f of files) {
+    try {
+      const { ok, source, onchain } = await verifyFile(f);
+      const status = ok ? "OK" : "MISMATCH";
+      console.log(`[${status}] chain=${f.chainId} file=${f.path}`);
+      console.log(`   source : ${source}`);
+      console.log(`   onchain: ${onchain}`);
+      if (!ok) allOk = false;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error(`[ERROR] chain=${f.chainId} file=${f.path}: ${msg}`);
+      allOk = false;
+    }
+  }
+
+  if (!allOk) {
+    console.error(
+      "\nOn-chain root does not match source merkle. acceptRoot() likely not yet executed — aborting publish.",
+    );
+    process.exit(1);
+  }
+  console.log("\nAll on-chain roots match source files. Safe to publish.");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a safeguard to the `publish` step in `vlcvx-distribution.yaml` and `vlaura-distribution.yaml`: before copying a merkle from `bounties-reports/<period>/` to `bounties-reports/latest/`, verify that the on-chain `root()` of the UniversalRewards distributor matches the `merkleRoot` in the source file. Mismatch exits non-zero, aborting the publish.

## Context

Commit [e5128c9a](https://github.com/stake-dao/bounties-report/commit/e5128c9a6fd06ac34c57401b413450786e42f69c) published a regenerated delegators merkle to `latest/` while no corresponding `acceptRoot()` had settled that merkle on-chain. The existing `Check if already published` step only guards on `source_exists && source != latest`, so any regeneration between accept cycles could leak through. Rolled back manually via [fcdcf911](https://github.com/stake-dao/bounties-report/commit/fcdcf911).

## Changes

- New `script/helpers/verifyOnchainRoot.ts` — reads `root()` (bytes32) via viem and compares to source `merkleRoot` per target:
  - `delegators` → `merkle_data_delegators.json` on chain 1 (`0x17F5…F380`)
  - `voters` → `vlcvx_merkle.json` on chain 1 + per-chain `vlcvx_merkle_{10,42161,8453}.json` (all at `0x0000…C4Db`)
  - `vlaura` → `vlaura_merkle.json` on chain 1 + `vlaura_merkle_{42161,8453}.json` (all at `0x59AD…9199`)
- Wired into both distribution workflows as a step guarded on `inputs.step == 'publish' && check_published.skip != 'true'`, placed before `Compute APR` / `Publish ... to latest`.
- Failure propagates to the existing `notify-failure` action.

## Validation

Ran against current period `1776297600` locally:

- `--target delegators` → **MISMATCH** (source `0x24ad…1e0b` ≠ on-chain `0x997b…a016`) — confirms this guard would have blocked the Tuesday incident.
- `--target voters` → OK (current cycle's Thursday voters root matches).
- `--target vlaura` → OK.

## Out of scope (flagged, not fixed here)

- `bribes-vlcvx-swap-delegators-vm.yaml` / `bribes-vlcvx-swap-delegators-votium.yaml` fire `repository_dispatch` event `generate-vlcvx-merkles` — no handler in `main` (removed in refactor `629e6227`). Dead dispatch.
- `vlcvx-distribution.yaml` allows manual workflow_dispatch with empty `dispatch_id` (produced commit `3ab94dab chore: vlCVX delegators-merkle []` off-cycle). Consider requiring non-empty `dispatch_id` for merkle regen steps.

## Test plan

- [ ] Run `vlcvx-distribution.yaml` step=publish type=delegators on a period where on-chain root matches → publish proceeds.
- [ ] Run the same where source has been regenerated but `acceptRoot()` not yet executed → verify step fails, nothing written to `latest/`, telegram failure alert fires.
- [ ] Same for type=voters (Thursday).
- [ ] Same for vlAURA.
- [ ] Confirm multi-chain voter/vlAURA files are each verified against their respective chain RPC.