### PR TITLE
chore(workflows): split distribution into per-sub-step dispatches

### DIFF
--- a/.github/workflows/sdtokens-merkle.yaml
+++ b/.github/workflows/sdtokens-merkle.yaml
@@ -13,11 +13,9 @@ on:
           - legacy
       step:
         description: 'Step to run'
-        required: false
+        required: true
         type: choice
-        default: 'all'
         options:
-          - all
           - merkle
           - publish
       dispatch_id:
@@ -49,7 +47,7 @@ jobs:
 
       # ── Spectra merkle ──
       - name: "Spectra: report + repartition + merkle"
-        if: inputs.token == 'spectra' && (inputs.step == 'all' || inputs.step == 'merkle')
+        if: inputs.token == 'spectra' && (inputs.step == 'merkle')
         run: |
           pnpm tsx script/spectra/1_report.ts
           pnpm tsx script/spectra/2_repartition.ts
@@ -60,7 +58,7 @@ jobs:
 
       # ── sdFXS merkle ──
       - name: "sdFXS: report + merkle"
-        if: inputs.token == 'sdfxs' && (inputs.step == 'all' || inputs.step == 'merkle')
+        if: inputs.token == 'sdfxs' && (inputs.step == 'merkle')
         run: make -f automation/sdfxs/run.mk run-merkle
         env:
           EXPLORER_KEY: ${{ secrets.ETHERSCAN_TOKEN }}
@@ -68,18 +66,18 @@ jobs:
 
       # ── Commit after merkle ──
       - name: Commit merkle
-        if: inputs.step == 'all' || inputs.step == 'merkle'
+        if: inputs.step == 'merkle'
         uses: ./.github/actions/commit-and-push
         with:
           message: "chore: ${{ inputs.token }} merkle [${{ inputs.dispatch_id }}]"
 
       # ── Publish ──
       - name: Pull latest before publish
-        if: inputs.step == 'all' || inputs.step == 'publish'
+        if: inputs.step == 'publish'
         run: git pull --rebase --autostash origin main
 
       - name: Calculate current period
-        if: inputs.step == 'all' || inputs.step == 'publish'
+        if: inputs.step == 'publish'
         id: period
         run: |
           WEEK=604800
@@ -88,7 +86,7 @@ jobs:
           echo "current=$CURRENT_PERIOD" >> $GITHUB_OUTPUT
 
       - name: "Spectra: publish to latest"
-        if: inputs.token == 'spectra' && (inputs.step == 'all' || inputs.step == 'publish')
+        if: inputs.token == 'spectra' && (inputs.step == 'publish')
         run: |
           PERIOD=${{ steps.period.outputs.current }}
           mkdir -p "bounties-reports/latest"
@@ -101,7 +99,7 @@ jobs:
           fi
 
       - name: "sdFXS: publish to latest"
-        if: inputs.token == 'sdfxs' && (inputs.step == 'all' || inputs.step == 'publish')
+        if: inputs.token == 'sdfxs' && (inputs.step == 'publish')
         run: |
           PERIOD=${{ steps.period.outputs.current }}
           mkdir -p "bounties-reports/latest/sdTkns"
@@ -114,7 +112,7 @@ jobs:
           fi
 
       - name: "Legacy: publish to latest"
-        if: inputs.token == 'legacy' && (inputs.step == 'all' || inputs.step == 'publish')
+        if: inputs.token == 'legacy' && (inputs.step == 'publish')
         run: |
           PERIOD=${{ steps.period.outputs.current }}
           mkdir -p "bounties-reports/latest/sdTkns"
@@ -137,7 +135,7 @@ jobs:
           fi
 
       - name: Merge delegationsAPRs
-        if: (inputs.token == 'spectra' || inputs.token == 'sdfxs') && (inputs.step == 'all' || inputs.step == 'publish')
+        if: (inputs.token == 'spectra' || inputs.token == 'sdfxs') && (inputs.step == 'publish')
         run: |
           PERIOD=${{ steps.period.outputs.current }}
           if [ -f "bounties-reports/${PERIOD}/delegationsAPRs.json" ]; then
@@ -153,7 +151,7 @@ jobs:
           fi
 
       - name: Compute sdPENDLE delegators APR
-        if: (inputs.token == 'spectra' || inputs.token == 'legacy') && (inputs.step == 'all' || inputs.step == 'publish')
+        if: (inputs.token == 'spectra' || inputs.token == 'legacy') && (inputs.step == 'publish')
         run: pnpm tsx script/helpers/computeSdPendleDelegatorsAPR.ts
         env:
           EXPLORER_KEY: ${{ secrets.ETHERSCAN_TOKEN }}
@@ -161,13 +159,13 @@ jobs:
         continue-on-error: true
 
       - name: Update round metadata
-        if: (inputs.token == 'legacy' || inputs.token == 'spectra') && (inputs.step == 'all' || inputs.step == 'publish')
+        if: (inputs.token == 'legacy' || inputs.token == 'spectra') && (inputs.step == 'publish')
         run: pnpm tsx script/helpers/getRoundMetadata.ts
         env:
           WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
 
       - name: Commit publish
-        if: inputs.step == 'all' || inputs.step == 'publish'
+        if: inputs.step == 'publish'
         uses: ./.github/actions/commit-and-push
         with:
           message: "chore: ${{ inputs.token }} publish [${{ inputs.dispatch_id }}]"

--- a/.github/workflows/vlaura-distribution.yaml
+++ b/.github/workflows/vlaura-distribution.yaml
@@ -10,11 +10,9 @@ on:
         default: ''
       step:
         description: 'Step to run'
-        required: false
-        default: 'all'
+        required: true
         type: choice
         options:
-          - all
           - repartition
           - merkle
           - publish
@@ -44,7 +42,7 @@ jobs:
 
       # ── Report Generation ──
       - name: Generate vlAURA report
-        if: inputs.step == 'all' || inputs.step == 'repartition'
+        if: inputs.step == 'repartition'
         run: make -f automation/reports.mk run-weekly-vlaura
         env:
           EXPLORER_KEY: ${{ secrets.ETHERSCAN_TOKEN }}
@@ -54,14 +52,14 @@ jobs:
           GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
 
       - name: Commit report
-        if: inputs.step == 'all' || inputs.step == 'repartition'
+        if: inputs.step == 'repartition'
         uses: ./.github/actions/commit-and-push
         with:
           message: "chore: vlAURA report [${{ inputs.dispatch_id }}]"
 
       # ── Repartition ──
       - name: Run repartition
-        if: inputs.step == 'all' || inputs.step == 'repartition'
+        if: inputs.step == 'repartition'
         run: make -f automation/distribution.mk run-repartition PROTOCOL=vlAURA
         env:
           EXPLORER_KEY: ${{ secrets.ETHERSCAN_TOKEN }}
@@ -70,18 +68,18 @@ jobs:
           VLAURA_GRAPHQL_ENDPOINT: https://snapshot-indexer.contact-69d.workers.dev/v1/graphql
 
       - name: Commit repartition
-        if: inputs.step == 'all' || inputs.step == 'repartition'
+        if: inputs.step == 'repartition'
         uses: ./.github/actions/commit-and-push
         with:
           message: "chore: vlAURA repartition [${{ inputs.dispatch_id }}]"
 
       # ── Merkle ──
       - name: Pull latest before merkle
-        if: inputs.step == 'all' || inputs.step == 'merkle'
+        if: inputs.step == 'merkle'
         run: git pull --rebase --autostash origin main
 
       - name: Create merkle
-        if: inputs.step == 'all' || inputs.step == 'merkle'
+        if: inputs.step == 'merkle'
         run: make -f automation/distribution.mk run-merkle PROTOCOL=vlAURA
         env:
           EXPLORER_KEY: ${{ secrets.ETHERSCAN_TOKEN }}
@@ -89,14 +87,14 @@ jobs:
           WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
 
       - name: Commit merkle
-        if: inputs.step == 'all' || inputs.step == 'merkle'
+        if: inputs.step == 'merkle'
         uses: ./.github/actions/commit-and-push
         with:
           message: "chore: vlAURA merkle [${{ inputs.dispatch_id }}]"
 
       # ── AI Verification ──
       - name: AI verify distribution
-        if: inputs.step == 'all' || inputs.step == 'merkle'
+        if: inputs.step == 'merkle'
         run: |
           WEEK=604800
           PERIOD=$(( $(date +%s) / WEEK * WEEK ))
@@ -108,7 +106,7 @@ jobs:
           TEST_TELEGRAM_API_KEY: ${{ secrets.TEST_TELEGRAM_API_KEY }}
           TEST_TELEGRAM_CHAT_ID: ${{ secrets.TEST_TELEGRAM_CHAT_ID }}
 
-      # ── Publish (only runs when explicitly requested, not with 'all') ──
+      # ── Publish (on-chain root verified, post-submit) ──
       - name: Pull latest before publish
         if: inputs.step == 'publish'
         run: git pull --rebase --autostash origin main

--- a/.github/workflows/vlaura-distribution.yaml
+++ b/.github/workflows/vlaura-distribution.yaml
@@ -14,7 +14,6 @@ on:
         default: 'all'
         type: choice
         options:
-          - full
           - all
           - repartition
           - merkle
@@ -45,7 +44,7 @@ jobs:
 
       # ── Report Generation ──
       - name: Generate vlAURA report
-        if: inputs.step == 'full' || inputs.step == 'all' || inputs.step == 'repartition'
+        if: inputs.step == 'all' || inputs.step == 'repartition'
         run: make -f automation/reports.mk run-weekly-vlaura
         env:
           EXPLORER_KEY: ${{ secrets.ETHERSCAN_TOKEN }}
@@ -55,14 +54,14 @@ jobs:
           GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
 
       - name: Commit report
-        if: inputs.step == 'full' || inputs.step == 'all' || inputs.step == 'repartition'
+        if: inputs.step == 'all' || inputs.step == 'repartition'
         uses: ./.github/actions/commit-and-push
         with:
           message: "chore: vlAURA report [${{ inputs.dispatch_id }}]"
 
       # ── Repartition ──
       - name: Run repartition
-        if: inputs.step == 'full' || inputs.step == 'all' || inputs.step == 'repartition'
+        if: inputs.step == 'all' || inputs.step == 'repartition'
         run: make -f automation/distribution.mk run-repartition PROTOCOL=vlAURA
         env:
           EXPLORER_KEY: ${{ secrets.ETHERSCAN_TOKEN }}
@@ -71,18 +70,18 @@ jobs:
           VLAURA_GRAPHQL_ENDPOINT: https://snapshot-indexer.contact-69d.workers.dev/v1/graphql
 
       - name: Commit repartition
-        if: inputs.step == 'full' || inputs.step == 'all' || inputs.step == 'repartition'
+        if: inputs.step == 'all' || inputs.step == 'repartition'
         uses: ./.github/actions/commit-and-push
         with:
           message: "chore: vlAURA repartition [${{ inputs.dispatch_id }}]"
 
       # ── Merkle ──
       - name: Pull latest before merkle
-        if: inputs.step == 'full' || inputs.step == 'all' || inputs.step == 'merkle'
+        if: inputs.step == 'all' || inputs.step == 'merkle'
         run: git pull --rebase --autostash origin main
 
       - name: Create merkle
-        if: inputs.step == 'full' || inputs.step == 'all' || inputs.step == 'merkle'
+        if: inputs.step == 'all' || inputs.step == 'merkle'
         run: make -f automation/distribution.mk run-merkle PROTOCOL=vlAURA
         env:
           EXPLORER_KEY: ${{ secrets.ETHERSCAN_TOKEN }}
@@ -90,14 +89,14 @@ jobs:
           WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
 
       - name: Commit merkle
-        if: inputs.step == 'full' || inputs.step == 'all' || inputs.step == 'merkle'
+        if: inputs.step == 'all' || inputs.step == 'merkle'
         uses: ./.github/actions/commit-and-push
         with:
           message: "chore: vlAURA merkle [${{ inputs.dispatch_id }}]"
 
       # ── AI Verification ──
       - name: AI verify distribution
-        if: inputs.step == 'full' || inputs.step == 'all' || inputs.step == 'merkle'
+        if: inputs.step == 'all' || inputs.step == 'merkle'
         run: |
           WEEK=604800
           PERIOD=$(( $(date +%s) / WEEK * WEEK ))

--- a/.github/workflows/vlcvx-distribution.yaml
+++ b/.github/workflows/vlcvx-distribution.yaml
@@ -17,7 +17,6 @@ on:
         type: choice
         options:
           - all
-          - repartition
           - merkle
           - publish
       dispatch_id:
@@ -56,7 +55,7 @@ jobs:
 
       # ── Report Generation (voters only) ──
       - name: Generate vlCVX report
-        if: inputs.type == 'voters' && (inputs.step == 'all' || inputs.step == 'repartition')
+        if: inputs.type == 'voters' && (inputs.step == 'all')
         run: make -f automation/reports.mk run-weekly-vlcvx
         env:
           EXPLORER_KEY: ${{ secrets.ETHERSCAN_TOKEN }}
@@ -65,25 +64,25 @@ jobs:
           GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
 
       - name: Commit report
-        if: inputs.type == 'voters' && (inputs.step == 'all' || inputs.step == 'repartition')
+        if: inputs.type == 'voters' && (inputs.step == 'all')
         uses: ./.github/actions/commit-and-push
         with:
           message: "chore: vlCVX report [${{ inputs.dispatch_id }}]"
 
       # ── Repartition (voters only) ──
       - name: Validate reports (pre-repartition)
-        if: inputs.type == 'voters' && (inputs.step == 'all' || inputs.step == 'repartition')
+        if: inputs.type == 'voters' && (inputs.step == 'all')
         run: make -f automation/distribution.mk validate-reports PROTOCOL=vlCVX
 
       - name: Run repartition
-        if: inputs.type == 'voters' && (inputs.step == 'all' || inputs.step == 'repartition')
+        if: inputs.type == 'voters' && (inputs.step == 'all')
         run: make -f automation/distribution.mk run-repartition PROTOCOL=vlCVX
         env:
           EXPLORER_KEY: ${{ secrets.ETHERSCAN_TOKEN }}
           WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
 
       - name: Commit repartition
-        if: inputs.type == 'voters' && (inputs.step == 'all' || inputs.step == 'repartition')
+        if: inputs.type == 'voters' && (inputs.step == 'all')
         uses: ./.github/actions/commit-and-push
         with:
           message: "chore: vlCVX repartition [${{ inputs.dispatch_id }}]"

--- a/.github/workflows/vlcvx-distribution.yaml
+++ b/.github/workflows/vlcvx-distribution.yaml
@@ -12,11 +12,10 @@ on:
           - delegators
       step:
         description: 'Step to run'
-        required: false
-        default: 'all'
+        required: true
         type: choice
         options:
-          - all
+          - repartition
           - merkle
           - publish
       dispatch_id:
@@ -55,7 +54,7 @@ jobs:
 
       # ── Report Generation (voters only) ──
       - name: Generate vlCVX report
-        if: inputs.type == 'voters' && (inputs.step == 'all')
+        if: inputs.type == 'voters' && inputs.step == 'repartition'
         run: make -f automation/reports.mk run-weekly-vlcvx
         env:
           EXPLORER_KEY: ${{ secrets.ETHERSCAN_TOKEN }}
@@ -64,49 +63,49 @@ jobs:
           GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
 
       - name: Commit report
-        if: inputs.type == 'voters' && (inputs.step == 'all')
+        if: inputs.type == 'voters' && inputs.step == 'repartition'
         uses: ./.github/actions/commit-and-push
         with:
           message: "chore: vlCVX report [${{ inputs.dispatch_id }}]"
 
       # ── Repartition (voters only) ──
       - name: Validate reports (pre-repartition)
-        if: inputs.type == 'voters' && (inputs.step == 'all')
+        if: inputs.type == 'voters' && inputs.step == 'repartition'
         run: make -f automation/distribution.mk validate-reports PROTOCOL=vlCVX
 
       - name: Run repartition
-        if: inputs.type == 'voters' && (inputs.step == 'all')
+        if: inputs.type == 'voters' && inputs.step == 'repartition'
         run: make -f automation/distribution.mk run-repartition PROTOCOL=vlCVX
         env:
           EXPLORER_KEY: ${{ secrets.ETHERSCAN_TOKEN }}
           WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
 
       - name: Commit repartition
-        if: inputs.type == 'voters' && (inputs.step == 'all')
+        if: inputs.type == 'voters' && inputs.step == 'repartition'
         uses: ./.github/actions/commit-and-push
         with:
           message: "chore: vlCVX repartition [${{ inputs.dispatch_id }}]"
 
       # ── Merkle ──
       - name: Pull latest before merkle
-        if: inputs.step == 'all' || inputs.step == 'merkle'
+        if: inputs.step == 'merkle'
         run: git pull --rebase --autostash origin main
 
       - name: Create merkle (delegators)
-        if: inputs.type == 'delegators' && (inputs.step == 'all' || inputs.step == 'merkle')
+        if: inputs.type == 'delegators' && inputs.step == 'merkle'
         run: make -f automation/distribution.mk run-merkles PROTOCOL=vlCVX TYPE=delegators
         env:
           EXPLORER_KEY: ${{ secrets.ETHERSCAN_TOKEN }}
           WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
 
       - name: Commit merkle delegators
-        if: inputs.type == 'delegators' && (inputs.step == 'all' || inputs.step == 'merkle')
+        if: inputs.type == 'delegators' && inputs.step == 'merkle'
         uses: ./.github/actions/commit-and-push
         with:
           message: "chore: vlCVX delegators-merkle [${{ inputs.dispatch_id }}]"
 
       - name: Create merkle (voters)
-        if: inputs.type == 'voters' && (inputs.step == 'all' || inputs.step == 'merkle')
+        if: inputs.type == 'voters' && inputs.step == 'merkle'
         run: make -f automation/distribution.mk run-merkles PROTOCOL=vlCVX TYPE=non-delegators
         env:
           EXPLORER_KEY: ${{ secrets.ETHERSCAN_TOKEN }}
@@ -114,14 +113,14 @@ jobs:
           FORCE_UPDATE: ${{ inputs.force_merkle && 'true' || 'false' }}
 
       - name: Commit merkle voters
-        if: inputs.type == 'voters' && (inputs.step == 'all' || inputs.step == 'merkle')
+        if: inputs.type == 'voters' && inputs.step == 'merkle'
         uses: ./.github/actions/commit-and-push
         with:
           message: "chore: vlCVX voters-merkle [${{ inputs.dispatch_id }}]"
 
       # ── AI Verification (voters only) ──
       - name: AI verify distribution (voters)
-        if: inputs.type == 'voters' && (inputs.step == 'all' || inputs.step == 'merkle')
+        if: inputs.type == 'voters' && inputs.step == 'merkle'
         run: |
           WEEK=604800
           PERIOD=$(( $(date +%s) / WEEK * WEEK ))
@@ -132,7 +131,7 @@ jobs:
           TEST_TELEGRAM_API_KEY: ${{ secrets.TEST_TELEGRAM_API_KEY }}
           TEST_TELEGRAM_CHAT_ID: ${{ secrets.TEST_TELEGRAM_CHAT_ID }}
 
-      # ── Publish (only runs when explicitly requested, not with 'all') ──
+      # ── Publish (on-chain root verified, post-submit) ──
       - name: Pull latest before publish
         if: inputs.step == 'publish'
         run: git pull --rebase --autostash origin main


### PR DESCRIPTION
## Summary

Orchestrator is the source of truth for sequencing. Workflows expose one sub-step per dispatch, matching the existing `sdtokens-merkle.yaml` pattern. `step=all` / `step=full` removed everywhere.

### Final state

| Workflow | Options |
|---|---|
| `vlcvx-distribution.yaml` | `repartition`, `merkle`, `publish` |
| `vlaura-distribution.yaml` | `repartition`, `merkle`, `publish` |
| `sdtokens-merkle.yaml` | `merkle`, `publish` |

### Changes by file

- **sdtokens-merkle**: drop unsafe `step=all` (it ran `publish` without the on-chain root verify guard that vlCVX / vlAURA enforce). Require explicit `merkle` or `publish`.
- **vlaura-distribution**: drop `full` (redundant alias of `all`, leftover from March 5 unified-step refactor that was cleaned up in vlCVX on March 19 but missed here). Drop `all`.
- **vlcvx-distribution**: drop `repartition` → re-scope (see second commit): put `repartition` back as its own explicit sub-step, drop `all` instead.

Paired PR: [`stake-dao/backend-monorepo#213`](https://github.com/stake-dao/backend-monorepo/pull/213) splits `vlcvx-distribution` + `vlaura-distribution` pipeline steps into `*-repartition` + `*-merkle`.

### Merge order

1. Merge this PR first so `step=all` / `step=full` are gone.
2. Then merge backend-monorepo PR #213 so orchestrator dispatches `step=repartition` then `step=merkle`.

Reverse order leaves one dispatched run sending a now-invalid `step=all`.

### Test plan

- [ ] Manual dispatch `vlcvx-distribution` type=voters, step=repartition — verify report + repartition run.
- [ ] Manual dispatch `vlcvx-distribution` type=voters, step=merkle — verify merkle + AI verify run.
- [ ] Manual dispatch `vlaura-distribution` step=repartition — verify report + repartition run.
- [ ] Manual dispatch `vlaura-distribution` step=merkle — verify merkle + AI verify run.
- [ ] Manual dispatch `sdtokens-merkle` token=sdfxs, step=merkle — verify merkle runs.
- [ ] Publish path unchanged — verify `step=publish` still gated on on-chain root check for vlcvx/vlaura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)