### PR TITLE
feat: add ai-verify-sdtokens workflow + spectra verify

### DIFF
--- a/.github/workflows/ai-verify-sdtokens.yaml
+++ b/.github/workflows/ai-verify-sdtokens.yaml
@@ -1,0 +1,67 @@
+name: "sdTokens: AI Verify"
+
+on:
+  workflow_dispatch:
+    inputs:
+      token:
+        description: 'sdToken to verify (e.g. sdfxs)'
+        required: true
+        type: string
+      epoch:
+        description: 'Epoch timestamp (default: current week)'
+        required: false
+        type: string
+        default: ''
+      dispatch_id:
+        description: 'Unique dispatch ID for Temporal tracking (do not remove)'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "dispatch_id:${{ inputs.dispatch_id || 'manual' }}"
+        run: echo "Dispatch ID - ${{ inputs.dispatch_id || 'manual' }}"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          fetch-depth: 0
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+
+      - name: AI verify sdToken distribution
+        run: |
+          case "${{ inputs.token }}" in
+            sdfxs) PROTOCOL=bounties ;;
+            *)
+              echo "❌ Unsupported token '${{ inputs.token }}': aiVerify.ts has no protocol mapping for it."
+              echo "   Supported: sdfxs. Extend script/verify/aiVerify.ts to add more."
+              exit 1
+              ;;
+          esac
+          if [ -n "${{ inputs.epoch }}" ]; then
+            PERIOD="${{ inputs.epoch }}"
+          else
+            WEEK=604800
+            PERIOD=$(( $(date +%s) / WEEK * WEEK ))
+          fi
+          echo "Token=${{ inputs.token }} Protocol=$PROTOCOL Period=$PERIOD"
+          pnpm tsx script/verify/aiVerify.ts --timestamp $PERIOD --protocol $PROTOCOL
+        env:
+          OPENCODE_ZEN_API_KEY: ${{ secrets.OPENCODE_ZEN_API_KEY }}
+          TEST_TELEGRAM_API_KEY: ${{ secrets.TEST_TELEGRAM_API_KEY }}
+          TEST_TELEGRAM_CHAT_ID: ${{ secrets.TEST_TELEGRAM_CHAT_ID }}
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-failure
+        with:
+          workflow_name: "sdTokens: AI Verify"
+          dispatch_id: ${{ inputs.dispatch_id }}
+          telegram_token: ${{ secrets.TG_API_KEY_BOT_ERROR }}

--- a/.github/workflows/ai-verify-sdtokens.yaml
+++ b/.github/workflows/ai-verify-sdtokens.yaml
@@ -38,10 +38,11 @@ jobs:
       - name: AI verify sdToken distribution
         run: |
           case "${{ inputs.token }}" in
-            sdfxs) PROTOCOL=bounties ;;
+            sdfxs)   PROTOCOL=bounties ;;
+            spectra) PROTOCOL=spectra ;;
             *)
               echo "❌ Unsupported token '${{ inputs.token }}': aiVerify.ts has no protocol mapping for it."
-              echo "   Supported: sdfxs. Extend script/verify/aiVerify.ts to add more."
+              echo "   Supported: sdfxs, spectra. Extend script/verify/aiVerify.ts to add more."
               exit 1
               ;;
           esac

--- a/script/sdTkns/generateUniversalMerkleFrax.ts
+++ b/script/sdTkns/generateUniversalMerkleFrax.ts
@@ -251,8 +251,7 @@ async function main() {
           cumulativeMerkleData,
           previousMerkleData,
           weekDistribution,
-          proposalId,
-          "252"
+          proposalId
         );
       } else {
         console.log("\nNo proposal found for verification");

--- a/script/sdTkns/generateUniversalMerkleSpectra.ts
+++ b/script/sdTkns/generateUniversalMerkleSpectra.ts
@@ -298,9 +298,8 @@ async function main() {
       SPECTRA_MERKLE_ADDRESS, 
       newMerkleData, 
       previousMerkleData, 
-      currentDistribution.distribution, 
-      proposalId, 
-      "8453"
+      currentDistribution.distribution,
+      proposalId
     );
     
     // Log contract address

--- a/script/utils/merkle/distributionVerifier.ts
+++ b/script/utils/merkle/distributionVerifier.ts
@@ -263,7 +263,7 @@ export const distributionVerifier = async (
   const tokenSums: { [token: string]: bigint } = {};
   for (const data of Object.values(distribution)) {
     for (const [token, amount] of Object.entries(data.tokens)) {
-      tokenSums[token] = (tokenSums[token] || 0n) + amount;
+      tokenSums[token] = (tokenSums[token] || 0n) + BigInt(amount);
     }
   }
   console.log("Token totals in current distribution (absolute):");

--- a/script/utils/merkle/distributionVerifier.ts
+++ b/script/utils/merkle/distributionVerifier.ts
@@ -255,7 +255,7 @@ export const distributionVerifier = async (
   previousMerkleData: MerkleData,
   distribution: { [address: string]: { tokens: { [token: string]: bigint } } },
   proposalId?: string,
-  merkleType?: string,
+  merkleType?: "forwarders" | "combined",
 ): Promise<DistributionRow[]> => {
   if (!proposalId) {
     throw new Error("distributionVerifier: proposalId is required");
@@ -406,7 +406,8 @@ export const distributionVerifier = async (
       gaugeType,
       currentMerkleData,
       previousMerkleData,
-      log
+      log,
+      merkleType
     );
   }
 

--- a/script/utils/merkle/distributionVerifier.ts
+++ b/script/utils/merkle/distributionVerifier.ts
@@ -256,7 +256,11 @@ export const distributionVerifier = async (
   distribution: { [address: string]: { tokens: { [token: string]: bigint } } },
   proposalId?: string,
   merkleType?: string,
-) => {
+): Promise<DistributionRow[]> => {
+  if (!proposalId) {
+    throw new Error("distributionVerifier: proposalId is required");
+  }
+
   const addressCount = Object.keys(distribution).length;
   console.log(`Current Distribution has ${addressCount} addresses.`);
 
@@ -402,10 +406,11 @@ export const distributionVerifier = async (
       gaugeType,
       currentMerkleData,
       previousMerkleData,
-      log,
-      merkleType
+      log
     );
   }
+
+  return comparisonRows;
 };
 
 const compareMerkleData = async (

--- a/script/verify/README.md
+++ b/script/verify/README.md
@@ -19,13 +19,14 @@ This directory contains automated verification for weekly distributions and boun
 `distributionVerify.ts` currently accepts:
 
 ```typescript
-export type Protocol = "vlCVX" | "bounties" | "all";
+export type Protocol = "vlCVX" | "bounties" | "spectra" | "all";
 ```
 
 Registered scripts:
 
 - vlCVX distribution, reward flow, claims completeness, parquet delegators, and RPC delegators.
 - bounty report verification through `verifyBountiesReport.ts`.
+- sdSPECTRA distribution verification through `verifySpectraDistribution.ts`.
 
 ## Usage
 
@@ -36,6 +37,7 @@ pnpm tsx script/verify/aiVerify.ts
 # Specific week/protocol
 pnpm tsx script/verify/aiVerify.ts --timestamp 1771459200 --protocol vlCVX
 pnpm tsx script/verify/aiVerify.ts --timestamp 1771459200 --protocol bounties
+pnpm tsx script/verify/aiVerify.ts --timestamp 1771459200 --protocol spectra
 
 # Override models
 pnpm tsx script/verify/aiVerify.ts --model claude-haiku-4-5

--- a/script/verify/aiVerify.ts
+++ b/script/verify/aiVerify.ts
@@ -6,7 +6,7 @@
  * if all scripts pass but every LLM is down, the pipeline still passes.
  *
  * Usage:
- *   pnpm tsx script/verify/aiVerify.ts [--timestamp WEEK] [--protocol vlCVX|bounties|all] [--models m1,m2] [--deep]
+ *   pnpm tsx script/verify/aiVerify.ts [--timestamp WEEK] [--protocol vlCVX|bounties|spectra|all] [--models m1,m2] [--deep]
  *
  * Env:
  *   OPENCODE_ZEN_API_KEY  (required)
@@ -118,7 +118,7 @@ Usage: pnpm tsx script/verify/aiVerify.ts [options]
 
 Options:
   --timestamp <ts>       Week epoch (default: current week)
-  --protocol  <p>        vlCVX | bounties | all  (default: all)
+  --protocol  <p>        vlCVX | bounties | spectra | all  (default: all)
   --models    <m1,m2>    Comma-separated model IDs (default: ${DEFAULT_MODELS.join(",")})
   --model     <m>        Single model (shorthand for --models with one)
   --deep                 Include RPC/parquet delegation checks (implicit)
@@ -137,7 +137,7 @@ Options:
   const clients: LLMClient[] = modelIds.map((m) => createZenClient(m, apiKey));
 
   const protocols: Protocol[] = protocol === "all"
-    ? ["vlCVX", "bounties"]
+    ? ["vlCVX", "bounties", "spectra"]
     : [protocol];
 
   let anyFail = false;

--- a/script/verify/compareModels.ts
+++ b/script/verify/compareModels.ts
@@ -9,7 +9,7 @@
  *
  * Options:
  *   --timestamp <ts>      Week epoch (default: current week)
- *   --protocol  <p>       vlCVX | bounties | all (default: all)
+ *   --protocol  <p>       vlCVX | bounties | spectra | all (default: all)
  *   --models    <m1,m2>   Comma-separated model IDs
  *   --deep                Include RPC/parquet delegation checks
  *
@@ -58,7 +58,7 @@ Usage: pnpm tsx script/verify/compareModels.ts [options]
 
 Options:
   --timestamp <ts>      Week epoch (default: current week)
-  --protocol  <p>       vlCVX | bounties | all (default: all)
+  --protocol  <p>       vlCVX | bounties | spectra | all (default: all)
   --models    <m1,m2>   Comma-separated model IDs (default: ${DEFAULT_MODELS.join(",")})
 `);
       process.exit(0);

--- a/script/verify/distributionVerify.ts
+++ b/script/verify/distributionVerify.ts
@@ -19,7 +19,7 @@ const MAX_BUFFER = 10 * 1024 * 1024;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-export type Protocol = "vlCVX" | "bounties" | "all";
+export type Protocol = "vlCVX" | "bounties" | "spectra" | "all";
 
 export type Verdict = "pass" | "fail" | "warning";
 
@@ -129,6 +129,13 @@ const SCRIPTS: VerifyScript[] = [
     path: "script/verify/verifyBountiesReport.ts",
     args: (ts) => ["--epoch", String(ts)],
     protocols: ["bounties", "all"],
+  },
+  // ── spectra ─────────────────────────────────────────────────
+  {
+    label: "sdSPECTRA Distribution Verification",
+    path: "script/verify/verifySpectraDistribution.ts",
+    args: (ts) => ["--timestamp", String(ts)],
+    protocols: ["spectra", "all"],
   },
 ];
 

--- a/script/verify/telegramReport.ts
+++ b/script/verify/telegramReport.ts
@@ -44,6 +44,7 @@ function shortLabel(label: string): string {
 function inferGroup(label: string): string {
   if (/^vlCVX/i.test(label)) return "vlCVX";
   if (/bounties/i.test(label)) return "Bounties";
+  if (/spectra/i.test(label)) return "Spectra";
   return "Other";
 }
 

--- a/script/verify/verifySpectraDistribution.ts
+++ b/script/verify/verifySpectraDistribution.ts
@@ -1,0 +1,96 @@
+/**
+ * sdSPECTRA distribution verification.
+ *
+ * Standalone re-run of the verification that generateUniversalMerkleSpectra.ts
+ * performs inline, so aiVerify.ts can gate the spectra-bribes set-roots step.
+ *
+ * Usage:
+ *   pnpm tsx script/verify/verifySpectraDistribution.ts [--timestamp WEEK]
+ */
+
+import * as dotenv from "dotenv";
+import * as fs from "fs";
+import * as path from "path";
+import { MerkleData } from "../interfaces/MerkleData";
+import { Distribution } from "../interfaces/Distribution";
+import { findPreviousMerkle } from "../utils/merkle/findPreviousMerkle";
+import { distributionVerifier } from "../utils/merkle/distributionVerifier";
+import { getLastClosedProposals } from "../utils/snapshot";
+import { SPECTRA_SPACE, WEEK } from "../utils/constants";
+import { base } from "../utils/chains";
+
+dotenv.config();
+
+const SPECTRA_MERKLE_ADDRESS =
+  "0x665d334388012d17f1d197de72b7b708ffccb67d" as `0x${string}`;
+const REPORTS = path.join(__dirname, "../../bounties-reports");
+
+function parseTimestamp(args: string[]): number {
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--timestamp" && args[i + 1]) {
+      return parseInt(args[i + 1], 10);
+    }
+  }
+  return Math.floor(Date.now() / 1000 / WEEK) * WEEK;
+}
+
+function loadCurrentMerkle(epoch: number): MerkleData {
+  for (const rel of ["sdTkns/sdtkns_merkle_8453.json", "spectra/merkle_data.json"]) {
+    const p = path.join(REPORTS, String(epoch), rel);
+    if (fs.existsSync(p)) {
+      console.log(`Current merkle: ${rel}`);
+      return JSON.parse(fs.readFileSync(p, "utf-8"));
+    }
+  }
+  throw new Error(`no sdSPECTRA merkle for week ${epoch} (sdTkns/ or spectra/)`);
+}
+
+function loadPreviousMerkle(epoch: number): { data: MerkleData; foundAt: string | null } {
+  const primary = findPreviousMerkle(epoch, "sdTkns/sdtkns_merkle_8453.json");
+  return primary.foundAt
+    ? primary
+    : findPreviousMerkle(epoch, "spectra/merkle_data.json");
+}
+
+async function main(): Promise<void> {
+  const epoch = parseTimestamp(process.argv.slice(2));
+  console.log(`sdSPECTRA distribution verification — week ${epoch}`);
+
+  const repartitionPath = path.join(REPORTS, String(epoch), "spectra/repartition.json");
+  if (!fs.existsSync(repartitionPath)) {
+    console.error(`❌ distribution file missing: ${repartitionPath}`);
+    process.exit(1);
+  }
+  const currentDistribution: { distribution: Distribution } = JSON.parse(
+    fs.readFileSync(repartitionPath, "utf-8")
+  );
+
+  const currentMerkleData = loadCurrentMerkle(epoch);
+  const { data: previousMerkleData, foundAt } = loadPreviousMerkle(epoch);
+  console.log(foundAt ? `Previous merkle: ${foundAt}` : "No previous merkle found");
+
+  // proposals[1]: bribes are claimed for the previous voting period, not the latest.
+  const proposals = await getLastClosedProposals(SPECTRA_SPACE, 2);
+  if (proposals.length < 2) {
+    console.error(`❌ expected 2 closed ${SPECTRA_SPACE} proposals, got ${proposals.length}`);
+    process.exit(1);
+  }
+  const proposalId = proposals[1].id;
+  console.log(`Verifying against proposal: ${proposalId}\n`);
+
+  await distributionVerifier(
+    SPECTRA_SPACE,
+    base,
+    SPECTRA_MERKLE_ADDRESS,
+    currentMerkleData,
+    previousMerkleData,
+    currentDistribution.distribution,
+    proposalId,
+    "8453"
+  );
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/script/verify/verifySpectraDistribution.ts
+++ b/script/verify/verifySpectraDistribution.ts
@@ -78,7 +78,7 @@ async function main(): Promise<void> {
   const proposalId = proposals[1].id;
   console.log(`Verifying against proposal: ${proposalId}\n`);
 
-  await distributionVerifier(
+  const rows = await distributionVerifier(
     SPECTRA_SPACE,
     base,
     SPECTRA_MERKLE_ADDRESS,
@@ -88,6 +88,20 @@ async function main(): Promise<void> {
     proposalId,
     "8453"
   );
+
+  // Every row's merkle delta (newAmount - prevAmount) must equal the amount
+  // repartition.json assigned that address — anything else is a mis-built tree.
+  const mismatches = rows.filter((r) => r.isError);
+  if (mismatches.length > 0) {
+    console.error(`\n❌ ${mismatches.length} of ${rows.length} rows do not reconcile:`);
+    for (const m of mismatches) {
+      console.error(
+        `  ${m.address} ${m.symbol}: repartition=${m.distributionAmount} merkleDelta=${m.weekChange}`
+      );
+    }
+    process.exit(1);
+  }
+  console.log(`\n✅ all ${rows.length} address/token rows reconcile with repartition.json`);
 }
 
 main().catch((err) => {

--- a/script/verify/verifySpectraDistribution.ts
+++ b/script/verify/verifySpectraDistribution.ts
@@ -85,8 +85,7 @@ async function main(): Promise<void> {
     currentMerkleData,
     previousMerkleData,
     currentDistribution.distribution,
-    proposalId,
-    "8453"
+    proposalId
   );
 
   // Every row's merkle delta (newAmount - prevAmount) must equal the amount

--- a/script/vlCVX/3_merkles/createDelegatorsMerkle.ts
+++ b/script/vlCVX/3_merkles/createDelegatorsMerkle.ts
@@ -707,7 +707,6 @@ async function processForwarders() {
 			previousMerkleData,
 			currentDistribution.distribution,
 			proposalId,
-			"1",
 			"forwarders",
 		);
 	} catch (error) {


### PR DESCRIPTION
## Why

The `fxs-bribes` and `spectra-bribes` Maestro pipelines (in `orchestrator`) have an `ai-verify` step that dispatches `bounties-report/ai-verify-sdtokens.yaml`. That file never existed — the dispatch 404'd and the pipeline failed at step 6/7 with a generic "Activity task failed".

## What

**Workflow** — `ai-verify-sdtokens.yaml`
- Wraps `script/verify/aiVerify.ts`; maps the `token` input to a protocol (`sdfxs` → `bounties`, `spectra` → `spectra`), fails loud on unsupported tokens.
- Carries the `dispatch_id:*` marker step Maestro needs to correlate the dispatched run.

**Spectra verification** — new `script/verify/verifySpectraDistribution.ts`
- Spectra had no verification path; it can't ride `verifyBountiesReport.ts` (different data shape — `merkle_data.json`/`repartition.json`, not CSV).
- Standalone re-run of the verification `generateUniversalMerkleSpectra.ts` does inline (wraps the shared `distributionVerifier`).
- `spectra` wired across the `Protocol` union and its sites (registry, `aiVerify`, `compareModels`, `telegramReport`, README).

**Real gate, not LLM-only**
- `distributionVerifier` returns its `DistributionRow[]`; `verifySpectraDistribution` exits non-zero when any merkle delta != `repartition.json` amount. Generators ignore the return — non-breaking.

**Bug fixes in `distributionVerifier`**
- Token-total sum did `0n + <string>` → string concatenation, garbage log. Coerced with `BigInt()`. Affected all callers.
- `proposalId` guarded instead of reaching `getProposal` as `undefined`.
- The 8th param `merkleType` was receiving a dead chain-id string from every caller (chain already comes from `merkleChain`); `createDelegatorsMerkle` also passed a phantom 9th `"forwarders"` arg the 8-param function silently dropped. Dropped the chain-id arg from all callers — `createDelegatorsMerkle`'s `"forwarders"` now lands in `merkleType`, so the vlCVX delegators merkle is verified through the forwarders path instead of silently as combined. `verifyVlCVXDistribution` returns void and only logs, so this is a logging change, no gate effect.

Smoke-tested `verifySpectraDistribution` against week 1741219200: end-to-end, exit 0, all 60 rows reconcile.

## Notes

- `verify-bounties.yaml` is superseded (zero runs, no marker step) — recommend deleting it.
- Untested in CI — run the workflow once manually (`token: sdfxs` and `token: spectra`) before relying on it.