### PR TITLE
fix(verify): bound AI-verify runtime so a stalled script can't hang f…

### DIFF
--- a/.github/workflows/ai-verify-sdtokens.yaml
+++ b/.github/workflows/ai-verify-sdtokens.yaml
@@ -21,6 +21,7 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: "dispatch_id:${{ inputs.dispatch_id || 'manual' }}"

--- a/script/verify/distributionVerify.ts
+++ b/script/verify/distributionVerify.ts
@@ -16,6 +16,8 @@ import type { LLMClient } from "../utils/llmClient";
 
 const PROJECT_ROOT = path.join(__dirname, "../../");
 const MAX_BUFFER = 10 * 1024 * 1024;
+/** Per-script wall-clock cap — a hung child (stalled RPC/HTTP) is killed, not waited on forever. */
+const SCRIPT_TIMEOUT_MS = 5 * 60 * 1000;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -153,14 +155,20 @@ function spawnScript(relPath: string, args: string[]): ScriptResult {
     cwd: PROJECT_ROOT,
     encoding: "utf-8",
     maxBuffer: MAX_BUFFER,
+    timeout: SCRIPT_TIMEOUT_MS,
     stdio: ["inherit", "pipe", "pipe"],
   });
   const out = result.stdout ?? "";
   const err = result.stderr ?? "";
+  const timedOut =
+    (result.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT";
+  const tail = timedOut
+    ? `\n[timeout] killed after ${SCRIPT_TIMEOUT_MS / 1000}s`
+    : "";
   return {
     label: relPath,
-    output: (err ? `${out}\n[stderr]\n${err}` : out).trim(),
-    exitCode: result.status ?? 1,
+    output: ((err ? `${out}\n[stderr]\n${err}` : out) + tail).trim(),
+    exitCode: timedOut ? 124 : result.status ?? 1,
   };
 }
 


### PR DESCRIPTION
…or hours

- spawnScript: 5-min per-script timeout — a hung child (stalled RPC/HTTP) is killed and reported as exit 124, not waited on forever
- ai-verify-sdtokens: 20-min job timeout-minutes backstop instead of GitHub's 6h default