### PR TITLE
feat(vlcvx): add AI verify workflow

### DIFF
--- a/.github/workflows/ai-verify-vlcvx.yaml
+++ b/.github/workflows/ai-verify-vlcvx.yaml
@@ -1,0 +1,70 @@
+name: "vlCVX: AI Verify"
+
+# Gate workflow used by the orchestrator vlcvx-delegators pipeline.
+# Wraps aiVerify.ts (`--protocol vlCVX --deep`) so verification verdict
+# determines pipeline progression: exit 0 = pass → set-root proceeds,
+# exit 1 = fail → pipeline halts before any on-chain action.
+
+on:
+  workflow_dispatch:
+    inputs:
+      type:
+        description: 'Distribution type (informational; same vlCVX verification runs for both)'
+        required: true
+        type: choice
+        options:
+          - delegators
+          - voters
+      epoch:
+        description: 'Epoch timestamp (default: current week)'
+        required: false
+        type: string
+        default: ''
+      dispatch_id:
+        description: 'Unique dispatch ID for Temporal tracking (do not remove)'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: "dispatch_id:${{ inputs.dispatch_id || 'manual' }}"
+        if: always()
+        run: echo "Temporal tracking"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          fetch-depth: 0
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+
+      - name: AI verify vlCVX distribution
+        run: |
+          if [ -n "${{ inputs.epoch }}" ]; then
+            PERIOD="${{ inputs.epoch }}"
+          else
+            WEEK=604800
+            PERIOD=$(( $(date +%s) / WEEK * WEEK ))
+          fi
+          echo "Type=${{ inputs.type }} Period=$PERIOD"
+          pnpm tsx script/verify/aiVerify.ts --timestamp $PERIOD --protocol vlCVX --deep
+        env:
+          OPENCODE_ZEN_API_KEY: ${{ secrets.OPENCODE_ZEN_API_KEY }}
+          WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
+          TEST_TELEGRAM_API_KEY: ${{ secrets.TEST_TELEGRAM_API_KEY }}
+          TEST_TELEGRAM_CHAT_ID: ${{ secrets.TEST_TELEGRAM_CHAT_ID }}
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-failure
+        with:
+          workflow_name: "vlCVX: AI Verify (${{ inputs.type }})"
+          dispatch_id: ${{ inputs.dispatch_id }}
+          telegram_token: ${{ secrets.TG_API_KEY_BOT_ERROR }}


### PR DESCRIPTION
## Summary
- New workflow `ai-verify-vlcvx.yaml`. Gate consumed by orchestrator pipeline `vlcvx-delegators`.
- Wraps `script/verify/aiVerify.ts --protocol vlCVX --deep`. Verdict `fail` exits non-zero → pipeline halts before set-root.
- Inputs: `type` (delegators|voters, informational), `epoch` (default current week), `dispatch_id`.

## Context
The orchestrator pipeline references this workflow but it never existed on main, so the `ai-verify` step failed last run. Same gap as the drain-check workflow.

Mirrors the inline call already used for voters in `vlcvx-distribution.yaml` and the pattern in `ai-verify-sdtokens.yaml`.

## Test plan
- [ ] Manual dispatch with `type: delegators` against current week → matches inline voters-mode result
- [ ] Force a fail (mismatch) → workflow exits non-zero, telegram notify fires