### PR TITLE
fix: noop publish-verify when no pending root yet

### DIFF
--- a/script/helpers/verifyOnchainRoot.ts
+++ b/script/helpers/verifyOnchainRoot.ts
@@ -75,7 +75,7 @@ function collectFiles(target: Target, period: number): FileSpec[] {
   return files;
 }
 
-type Status = "OK" | "READY" | "PENDING" | "BLOCK";
+type Status = "OK" | "READY" | "PENDING" | "WAITING" | "BLOCK";
 
 interface VerifyResult {
   status: Status;
@@ -125,6 +125,13 @@ export function classifyRootStatus(input: RootStatusInput): Pick<VerifyResult, "
     return {
       status: "PENDING",
       reason: `pending root matches source, timelock validAt=${input.pendingValidAt} > now=${input.now}`,
+    };
+  }
+
+  if (!hasPending) {
+    return {
+      status: "WAITING",
+      reason: "no pending root on-chain yet; set-root has not been called for this period",
     };
   }
 
@@ -226,6 +233,7 @@ async function main() {
   console.log(`Verifying on-chain roots for target=${target} period=${period}`);
   let hasBlock = false;
   let hasPending = false;
+  let hasWaiting = false;
   let hasReady = false;
 
   for (const f of files) {
@@ -241,6 +249,7 @@ async function main() {
       }
       if (res.status === "BLOCK") hasBlock = true;
       if (res.status === "PENDING") hasPending = true;
+      if (res.status === "WAITING") hasWaiting = true;
       if (res.status === "READY") hasReady = true;
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
@@ -257,6 +266,11 @@ async function main() {
   if (hasPending) {
     emitOutput("skip", "true");
     console.log("\nActive pending root timelock detected. Skipping publish.");
+    return;
+  }
+  if (hasWaiting) {
+    emitOutput("skip", "true");
+    console.log("\nNo pending root on-chain yet (set-root not called). Skipping publish.");
     return;
   }
   emitOutput("skip", "false");

--- a/script/test/unit/verifyOnchainRoot.test.ts
+++ b/script/test/unit/verifyOnchainRoot.test.ts
@@ -43,11 +43,24 @@ describe("classifyRootStatus", () => {
     expect(result.status).toBe("OK");
   });
 
-  it("blocks publish when neither on-chain nor pending root matches source", () => {
+  it("waits (noop) when no pending root has been submitted yet", () => {
     const result = classifyRootStatus({
       source: SOURCE_ROOT,
       onchain: OLD_ROOT,
       pendingRoot: ZERO_ROOT,
+      pendingValidAt: 0n,
+      now: 1_000,
+    });
+
+    expect(result.status).toBe("WAITING");
+    expect(result.reason).toContain("set-root has not been called");
+  });
+
+  it("blocks publish when pending root is present but does not match source", () => {
+    const result = classifyRootStatus({
+      source: SOURCE_ROOT,
+      onchain: OLD_ROOT,
+      pendingRoot: OLD_ROOT,
       pendingValidAt: 0n,
       now: 1_000,
     });


### PR DESCRIPTION
## Summary
- `classifyRootStatus`: split the "ZERO pendingRoot + on-chain mismatch" case off from `BLOCK` into a new `WAITING` status (skip + exit 0). `BLOCK` is now reserved for the genuine mismatch case where a non-zero pending root differs from source.
- `main()`: handle `WAITING` like `PENDING` — emit `skip=true`, exit 0.

Avoids spurious failure alerts when the Thursday accept-loop in `merkle-accept-pending-roots.yaml` fires `vlcvx-distribution.yaml publish` before set-root has been called for the voters distributor (same shape for delegators on Tuesday).

Triggering incident: dispatch_id `26574106570-238`, run https://github.com/stake-dao/bounties-report/actions/runs/26574162737 — failed at `Verify on-chain root matches source` because pendingRoot was ZERO.

## Test plan
- [x] `pnpm test:unit script/test/unit/verifyOnchainRoot.test.ts` — all green (56 tests).
- [x] Renamed the old "blocks publish when neither on-chain nor pending root matches source" test to assert `WAITING`.
- [x] Added a new test that still asserts `BLOCK` when pendingRoot is present but does not match source.