### PR TITLE
feat(verify): swap AI verify lineup + drop balancer

### DIFF
--- a/script/utils/openCodeZen.ts
+++ b/script/utils/openCodeZen.ts
@@ -6,7 +6,7 @@
  * when the upstream Anthropic API returns any non-200 response.
  *
  * Usage:
- *   const client = createZenClient();           // kimi-k2 (default)
+ *   const client = createZenClient();           // kimi-k2.6 (default)
  *   const text   = await client.ask("...");
  *   const parsed = await client.analyzeJson<MyType>("...", fallback);
  */
@@ -17,7 +17,7 @@ import type { LLMClient, LLMMessage, LLMOptions, LLMJsonResult } from "./llmClie
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 const ZEN_BASE_URL = "https://opencode.ai/zen/v1";
-export const ZEN_DEFAULT_MODEL = "kimi-k2";
+export const ZEN_DEFAULT_MODEL = "kimi-k2.6";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/script/verify/README.md
+++ b/script/verify/README.md
@@ -41,9 +41,9 @@ pnpm tsx script/verify/aiVerify.ts --timestamp 1771459200 --protocol bounties
 pnpm tsx script/verify/aiVerify.ts --timestamp 1771459200 --protocol spectra
 pnpm tsx script/verify/aiVerify.ts --timestamp 1771459200 --protocol frax
 
-# Override models
-pnpm tsx script/verify/aiVerify.ts --model claude-haiku-4-5
-pnpm tsx script/verify/aiVerify.ts --models claude-haiku-4-5,gpt-5.4-mini,minimax-m2.5-free
+# Override models (defaults: claude-opus-4-7, gpt-5.5, minimax-m2.7)
+pnpm tsx script/verify/aiVerify.ts --model claude-opus-4-7
+pnpm tsx script/verify/aiVerify.ts --models claude-opus-4-7,gpt-5.5,minimax-m2.7
 
 # Model comparison without consensus reporting
 pnpm tsx script/verify/compareModels.ts --timestamp 1771459200 --protocol vlCVX

--- a/script/verify/aiVerify.ts
+++ b/script/verify/aiVerify.ts
@@ -25,9 +25,9 @@ import type { LLMClient } from "../utils/llmClient";
 dotenv.config();
 
 const DEFAULT_MODELS = [
-  "claude-haiku-4-5",
-  "gpt-5.4-mini",
-  "minimax-m2.5-free",
+  "claude-opus-4-7",
+  "gpt-5.5",
+  "minimax-m2.7",
 ];
 
 const VERDICT_ICON: Record<string, string> = { pass: "✅", warning: "⚠️ ", fail: "❌" };

--- a/script/verify/compareModels.ts
+++ b/script/verify/compareModels.ts
@@ -14,7 +14,7 @@
  *   --deep                Include RPC/parquet delegation checks
  *
  * Available ZEN models: GET https://opencode.ai/zen/v1/models
- * Free options: kimi-k2.5-free, minimax-m2.5-free, big-pickle, glm-5-free
+ * Free options: minimax-m2.5-free, deepseek-v4-flash-free, mimo-v2.5-free, nemotron-3-super-free, qwen3.6-plus-free
  *
  * Env:
  *   OPENCODE_ZEN_API_KEY  (required)
@@ -22,15 +22,15 @@
 
 import * as dotenv from "dotenv";
 import { runScripts, analyze, Protocol, VerificationResult } from "./distributionVerify";
-import { createZenClient, ZEN_DEFAULT_MODEL } from "../utils/openCodeZen";
+import { createZenClient } from "../utils/openCodeZen";
 import { WEEK } from "../utils/constants";
 
 dotenv.config();
 
 const DEFAULT_MODELS = [
-  ZEN_DEFAULT_MODEL,          // best quality (claude-sonnet-4-6)
-  "claude-haiku-4-5",         // fast, cheap
-  "kimi-k2.5-free",           // free — OpenAI-compat
+  "claude-opus-4-7",          // Anthropic frontier
+  "gpt-5.5",                  // OpenAI frontier (non-pro: avoids reasoning-overflow truncation)
+  "minimax-m2.7",             // Minimax frontier (provider diversity)
 ];
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/script/verify/distributionVerify.ts
+++ b/script/verify/distributionVerify.ts
@@ -207,8 +207,13 @@ Root gauge note: Curve L2 gauges (rootGauge on Arbitrum/Base) are resolved to th
 - ❌  "gauge in claimed_bounties but NOT in CSV" → CRITICAL: bounty claimed on-chain but not distributed
 - ❌  "frax.csv missing" when frax has claimed bounties → CRITICAL
 - ❌  "sdInTotal mismatch > 0.5%" → CRITICAL: swap amounts don't reconcile with CSV
-Only frax is in scope here — curve/balancer/fxn are deliberately excluded from the sdFXS gate.`,
-  vlCVX: `CSV mismatch triage for vlCVX:
+Only frax is in scope here — curve/fxn are deliberately excluded from the sdFXS gate.`,
+  vlCVX: `Distribution timing for vlCVX (Curve+FXN):
+- Thursday run = VOTERS distribution. Forwarder slices are NOT yet included; "forwarder missing", "fwd=0", "parquet off-by-one", or a 1-row delta between parquet/RPC counts driven by forwarders is EXPECTED, not anomalous. Do NOT WARN on it.
+- Tuesday run = DELEGATORS distribution. Forwarders join here; parquet and RPC counts (incl. fwd splits) must reconcile.
+Infer day-of-week from the "Week:" header date and apply the rule above before flagging any forwarder-related drift.
+
+CSV mismatch triage for vlCVX:
 1. CSV diff≠0 + token NOT in merkle → CRITICAL FAIL: funds computed but never distributed.
 2. CSV diff≠0 + token IS in merkle  → WARNING only: known cause — isWrapped=true bounties on Arbitrum/Base votemarket-v2 produce unwrapped tokens that bypass the CSV generator. Funds reached delegators correctly.
 When you see a CSV mismatch, check whether the script output mentions the token appearing in merkle claims. If merkle claim count for that token is non-zero, classify as warning not fail.
@@ -234,11 +239,14 @@ Week: ${timestamp} (${date})  |  Protocol: ${protocol}
 Analyze the verification script outputs below. Each script tests a different aspect of the distribution pipeline. You must:
 1. Read each script's output and determine if it passed
 2. Cross-validate numbers BETWEEN scripts (e.g., delegator counts from parquet vs RPC should be consistent)
-3. Flag anything anomalous even if the script itself passed (counts outside baseline range, unexpected patterns)
+3. Flag anything anomalous even if the script itself passed (cross-script inconsistencies, unexpected patterns, missing data)
 4. Classify your confidence in the overall result
 
-## BASELINE EXPECTATIONS (typical healthy week)
-- vlCVX: 200–300 merkle claims, 30–50 tokens, 280–350 delegators, zero-VP filtered: 50–100
+## BASELINE EXPECTATIONS (typical healthy week — informational, NOT a hard band)
+The numbers below describe the typical operating range; they organically drift up over time as the protocol grows. Counts within or slightly above this range are EXPECTED and must NOT be flagged as warnings on size alone.
+- vlCVX: ~200–400 merkle claims, ~30–60 tokens, ~250–500 delegators, zero-VP filtered: ~50–150
+- A delegator count up to ~1.5× the upper bound = organic growth, not anomalous
+- Only WARN on size if the count is below the lower bound (potential data loss) or more than ~2× the upper bound (potential duplicate run)
 - CSV diff should be exactly 0 for all tokens
 - Cumulative merkle: prev + this_week amounts (diff < 1e-9 relative is acceptable BigInt rounding)
 - Group split (fwd + nfwd) must be exact (0 diff)
@@ -276,8 +284,8 @@ Respond with ONLY a raw JSON object (no markdown, no text outside JSON):
 ## FIELD RULES
 
 confidence:
-- 0.95–1.0: all checks pass, cross-checks consistent, counts within baseline ranges
-- 0.7–0.94: minor anomalies (e.g., unusual count delta) but no failures
+- 0.95–1.0: all checks pass and cross-checks consistent (counts within or slightly above baseline counts as healthy)
+- 0.7–0.94: minor anomalies (cross-script inconsistency, unexpected pattern) but no failures
 - <0.7: uncertain — ambiguous outputs, mixed signals
 
 issues:
@@ -356,7 +364,7 @@ export async function analyze(
     cross_check_notes?: string[];
     chain_status?: Record<string, Verdict>;
     week_context?: "A" | "B" | "unknown";
-  }>(prompt, fallback, { maxTokens: 2048, timeout: 90_000 });
+  }>(prompt, fallback, { maxTokens: 4096, timeout: 180_000 });
 
   if (error) console.warn(`  ⚠️  LLM error (${client.model}): ${error}`);
 

--- a/script/verify/verifyBountiesReport.ts
+++ b/script/verify/verifyBountiesReport.ts
@@ -50,7 +50,7 @@ const REPORTS_DIR = path.join(__dirname, "../../bounties-reports");
 const WEEKLY_DIR = path.join(__dirname, "../../weekly-bounties");
 const WEEK = 604800;
 
-const PROTOCOLS = ["curve", "balancer", "frax", "fxn"] as const;
+const PROTOCOLS = ["curve", "frax", "fxn"] as const;
 type Protocol = (typeof PROTOCOLS)[number];
 
 const BOT_MARKET = "0xADfBFd06633eB92fc9b58b3152Fe92B0A24eB1FF" as const;


### PR DESCRIPTION
## Summary

Two problems surfaced by the live Thursday vlCVX run:
1. The model panel `claude-haiku-4-5 / gpt-5.4-mini / minimax-m2.5-free` produced a spurious WARN on the new ~380 delegator count (organic growth above the hardcoded `280–350` baseline), and `minimax-m2.5-free` is consistently dead.
2. The bounties verifier still required `balancer.csv`, failing the gate now that balancer has no more claims/distributions.

This PR adapts both.

### Model lineup
- `DEFAULT_MODELS` → `claude-opus-4-7`, `gpt-5.5`, `minimax-m2.7`
- All three are paid-tier frontier from three distinct vendors (Anthropic / OpenAI / MiniMax).
- Probed and rejected the `*-pro` / reasoning-heavy variants (`gpt-5.5-pro`, `kimi-k2.5/2.6`, `big-pickle`): hidden reasoning tokens consume the entire `max_tokens` budget, leaving the JSON content empty or truncated mid-object → `extractJson` throws "No JSON object found". The chosen non-pro variants emit content directly.
- `compareModels.ts` aligned to the same lineup; dropped its now-unused `ZEN_DEFAULT_MODEL` import; refreshed the stale "Free options" doc comment.
- `ZEN_DEFAULT_MODEL` was `"kimi-k2"`, which is not in the current ZEN catalog (would 404 if a caller ever used `createZenClient()` without an explicit model). Bumped to `"kimi-k2.6"`.

### LLM call budget (`distributionVerify.ts`)
- `maxTokens: 2048 → 4096` — accommodates models that emit short reasoning before the JSON.
- `timeout: 90s → 180s` — Anthropic backend latency through ZEN is bursty; opus regularly takes 90–150 s on a full prompt.

### Prompt fixes (`distributionVerify.ts`)
- **Baseline relaxed**: the static `280–350 delegators` band was triggering false WARNs on organic growth. Reframed as informational ("typical operating range; counts within or slightly above are expected"), explicit rule: WARN only on counts below the lower bound or > 2× upper bound. Widened bands to current shape: ~250–500 delegators, ~30–60 tokens, ~200–400 claims.
- **vlCVX timing rule** added to `PROTOCOL_CONTEXT`:
  > Thursday = voters distribution. Forwarder slices are NOT yet included; "forwarder missing"/parquet off-by-one/1-row parquet-vs-RPC delta is EXPECTED. Do NOT WARN on it.
  > Tuesday = delegators distribution. Forwarders join here.
- **Step 3 instruction**: dropped "counts outside baseline range" from the "Flag anomalies" prompt step (contradicted the relaxed baseline).
- **Confidence rule**: 0.95+ tier no longer requires "counts within baseline ranges".

### Balancer drop
- `verifyBountiesReport.ts:53` — `PROTOCOLS` array drops `"balancer"`. Verification stops requiring `balancer.csv`.
- Frax section comment in `distributionVerify.ts:210` no longer lists balancer.
- Scoped to verify path only per request; claims/merkle/reports code keeps its dormant balancer references.

## Validation runs

Local end-to-end against the latest available data, with the new lineup:

| Protocol | Period | Verdict | Consensus | Notes |
|---|---|---|---|---|
| vlCVX | 1779926400 | **unanimous PASS** | 3/3 | Thursday rule applied — no forwarder/off-by-one WARN |
| bounties | 1779321600 | majority WARN | 3/3 | Real ORDER-mismatch dropped token; previously FAILed on missing `balancer.csv` |
| spectra | 1779321600 | majority FAIL | 3/3 | Real upstream Snapshot 504 — would also have failed under the old lineup |
| frax | 1779321600 | unanimous PASS | 3/3 | clean |

No "delegator counts exceed baseline" warning across any run. All 3 models responded on every protocol (no `script-only` fallback).

## Test plan
- [x] `pnpm test:unit` — 56/56 passing.
- [x] `pnpm tsx script/verify/aiVerify.ts --help` — shows new defaults.
- [x] No stale model IDs in non-test code (`grep -rn "minimax-m2.5-free\|gpt-5.4-mini\|claude-haiku-4-5" script/` clean).
- [x] Full vlCVX, bounties, spectra, frax verify runs hit ZEN and produced expected verdicts (see table above).
- [ ] After merge, watch one production run per gate (vlCVX merkle + delegators, bounties, sdtokens).