### PR TITLE
fix(vlCVX): use AllMight V2 for delegators sCRVUSD split

### DIFF
--- a/script/vlCVX/3_merkles/createDelegatorsMerkle.ts
+++ b/script/vlCVX/3_merkles/createDelegatorsMerkle.ts
@@ -15,6 +15,7 @@ import { createCombineDistribution } from "../../utils/merkle/merkle";
 import { findPreviousMerkle } from "../../utils/merkle/findPreviousMerkle";
 // Removed unused price utils imports
 import {
+	ALL_MIGHT_V2,
 	CRV_ADDRESS,
 	WETH_ADDRESS,
 	mapTokenSwapsToOutToken,
@@ -328,7 +329,7 @@ async function getProtocolShares(
 			vmTxHashes[0],
 			vmTokens,
 			WETH_ADDRESS,
-			"0x0000000a3Fc396B89e4c11841B39D9dff85a5D05",
+			ALL_MIGHT_V2,
 		);
 		vmTokenToWeth = normalizeMap(rawVmTokenToWeth);
 
@@ -337,7 +338,7 @@ async function getProtocolShares(
 			vmTxHashes[0],
 			new Set([WETH_ADDRESS.toLowerCase(), CRV_ADDRESS.toLowerCase()]),
 			CRVUSD,
-			"0x0000000a3Fc396B89e4c11841B39D9dff85a5D05",
+			ALL_MIGHT_V2,
 		);
 		vmTokenToCrvUSD = normalizeMap(rawVmTokenToCrvUSD);
 	}
@@ -348,7 +349,7 @@ async function getProtocolShares(
 			votiumTxHashes[0],
 			votiumTokens,
 			WETH_ADDRESS,
-			"0x0000000a3Fc396B89e4c11841B39D9dff85a5D05",
+			ALL_MIGHT_V2,
 		);
 		votiumTokenToWeth = normalizeMap(rawVotiumTokenToWeth);
 
@@ -357,7 +358,7 @@ async function getProtocolShares(
 			votiumTxHashes[0],
 			new Set([WETH_ADDRESS.toLowerCase(), CRV_ADDRESS.toLowerCase()]),
 			CRVUSD,
-			"0x0000000a3Fc396B89e4c11841B39D9dff85a5D05",
+			ALL_MIGHT_V2,
 		);
 		votiumTokenToCrvUSD = normalizeMap(rawVotiumTokenToCrvUSD);
 	}


### PR DESCRIPTION
## Problem
vlCVX delegators (Votium forwarders) sCRVUSD merkle flatlined — week `1779926400` was byte-identical to the prior week, zero weekly addition despite 39,195 sCRVUSD landing on the merkle contract on-chain.

## Cause
`getProtocolShares` splits the received sCRVUSD between Curve and FXN by parsing the swap events inside the deposit txs via `mapTokenSwapsToOutToken`, which only matches transfers from/to a given swapper address. That address was hardcoded to AllMight **V1** (`0x0000000a3Fc…`). After the AllMight **V2** migration (router `0xDBd24b09…`), the parser matched nothing → `finalTokenCrvUSD` empty → `curve=0, fxn=0` → `computeShares(0)` → merkle frozen.

Only bites when FXN delegation exists (the no-FXN path dumps everything to Curve and skips swap parsing). Commit 1254089d migrated the report path V1→V2 but missed this file.

## Fix
Point the 4 `mapTokenSwapsToOutToken` call sites at `ALL_MIGHT_V2`, mirroring 1254089d. V1 is no longer used.

## Test (local, forced re-run)
| | before | after |
|---|---|---|
| merkle root | `0xada6454f…` | `0x8304c289…` |
| weekly delta | 0 | **39,195.702 sCRVUSD** |
| forwarders | 451 | 471 |

Weekly delta matches on-chain received to the wei; script integrity check passes.

## Follow-up
Re-run the Tuesday job (`FORCE_MERKLE=true`) to regenerate + publish the corrected merkle. Funds are safe in the contract meanwhile.