### PR TITLE
fix(ci): wire force_merkle to vlCVX delegators merkle step

### DIFF
--- a/.github/workflows/vlcvx-distribution.yaml
+++ b/.github/workflows/vlcvx-distribution.yaml
@@ -97,6 +97,7 @@ jobs:
         env:
           EXPLORER_KEY: ${{ secrets.ETHERSCAN_TOKEN }}
           WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
+          FORCE_MERKLE: ${{ inputs.force_merkle && 'true' || 'false' }}
 
       - name: Commit merkle delegators
         if: inputs.type == 'delegators' && inputs.step == 'merkle'


### PR DESCRIPTION
The `force_merkle` dispatch input was only wired to the voters merkle step (`FORCE_UPDATE`). The delegators step (`createDelegatorsMerkle.ts`, which reads `FORCE_MERKLE`) never received it, so dispatching `type=delegators step=merkle force_merkle=true` hit the idempotency guard and regenerated nothing when the week's file already existed.

Forward `FORCE_MERKLE` to the delegators step. Needed to regenerate the corrected merkle after #143.