### PR TITLE
fix(sdfxs): pass BOTS_ENVIO_GRAPHQL_URL_WORKER to merkle step

### DIFF
--- a/.github/workflows/sdtokens-merkle.yaml
+++ b/.github/workflows/sdtokens-merkle.yaml
@@ -64,6 +64,7 @@ jobs:
         env:
           EXPLORER_KEY: ${{ secrets.ETHERSCAN_TOKEN }}
           WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
+          BOTS_ENVIO_GRAPHQL_URL_WORKER: ${{ secrets.BOTS_ENVIO_GRAPHQL_URL_WORKER }}
 
       # ── Commit after merkle ──
       - name: Commit merkle


### PR DESCRIPTION
## Problem
`fxs-bribes` pipeline fails at `generate-merkle` every run:
```
Error generating sdFXS merkle: Error: BOTS_ENVIO_GRAPHQL_URL_WORKER environment variable is not set
  at fetchGraphQL (script/utils/envioClient.ts:13)
  at fetchGlobalTotalVp (script/utils/envioClient.ts:76)
  at main (script/sdTkns/generateUniversalMerkleFrax.ts:92)
```

## Cause
The sdFXS merkle step runs `generateUniversalMerkleFrax`, which now fetches global VP through the envio client (`BOTS_ENVIO_GRAPHQL_URL_WORKER`). The var was wired into the Spectra merkle step but missed on the sdFXS step.

## Fix
Pass the secret to the sdFXS step env, matching the Spectra step.

Diagnosed from GH run `27354104169` (child of `sdfxs-merkle.yaml` dispatch).